### PR TITLE
Block until firmware job request

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,4 +2,4 @@ file(GLOB OTA_SRCS "src/*.c")
 
 idf_component_register(SRCS ${OTA_SRCS} INCLUDE_DIRS "src" "include"
 		       EMBED_TXTFILES certs/server.crt
-		       REQUIRES mbedtls nvs_flash app_update esp_netif esp_event)
+		       REQUIRES mbedtls nvs_flash app_update esp_netif esp_event esp_http_server)


### PR DESCRIPTION
`ota-service` initializes a web server, listening
on `/update` endpoint. Only when it gets a GET
request there, it will start the ota task.